### PR TITLE
test_circuits/iris.py: fix https://github.com/mawatfa/ebana/issues/2

### DIFF
--- a/test_circuits/iris.py
+++ b/test_circuits/iris.py
@@ -43,7 +43,7 @@ def get_iris_dataset(scale=4, split_size=0.7):
     X = np.round(
         scale * preprocessing.MinMaxScaler(feature_range=(-1, 1)).fit_transform(X), 2
     )
-    Y = OneHotEncoder(sparse=False).fit_transform(Y.reshape(-1, 1))
+    Y = OneHotEncoder(sparse_output=False).fit_transform(Y.reshape(-1, 1))
 
     p = np.random.permutation(len(Y))
     X_shuffled, Y_shuffled = X[p], Y[p]


### PR DESCRIPTION
fix TypeError: OneHotEncoder.__init__() got an unexpected keyword argument sparse

`sparse` was renamed to `sparse_output` in
sklearn/preprocessing/_encoders.py